### PR TITLE
Add jet conv model

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,10 @@ cmsenv
 git clone https://github.com/jmduarte/L1METML
 cd L1METML
 ```
-Create an anaconda environment with Python 3.5-3.7   
-In order to run 'convert-uproot.py', you need to install [uproot](https://github.com/scikit-hep/uproot "uproot link").
+Create an anaconda environment with Python 3.6 and install packages needed to run train.py.
 ```
-conda config --add channels conda-forge
-conda install uproot
+sh conda_setup.sh
 ```
-And you need to install following packages.
-These can be installed by "conda install [package name]"
-* [numpy](https://scipy.org/install.html)
-* [matplotlib](https://matplotlib.org/)
-* [awkward-array](https://github.com/scikit-hep/awkward-array)
-* [uproot-methods](https://github.com/scikit-hep/uproot-methods)
-* [cachetools](https://pypi.org/project/cachetools/)
-* [pandas](https://pandas.pydata.org/)
-* [tables](https://pypi.org/project/tables/)
-* [tensorflow](https://www.tensorflow.org/install)
-* [keras](https://keras.io/#installation)
 
 ### Convert
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ sh conda_setup.sh
 ```
 
 ### Convert
+The TTBar sample used in 'convert-uproot.py' is located in
+```
+/afs/cern.ch/work/y/yeseo/public/ml4MET/L1METML/data/perfNano_TTbar_PU200.110X_v1.root
+```
+Convert into hdf5
 ```
 python convert-uproot.py
 ```

--- a/conda_setup.sh
+++ b/conda_setup.sh
@@ -1,0 +1,9 @@
+conda create -n l1metml python=3.6
+conda activate l1metml
+conda install -c conda-forge uproot
+conda install -c anaconda pytables
+conda install -c anaconda tensorflow-gpu
+conda install keras
+conda install pandas
+conda install -c conda-forge matplotlib
+pip install setGPU

--- a/convert-uproot.py
+++ b/convert-uproot.py
@@ -15,7 +15,7 @@ infiles = [#path+'perfNano_SingleNeutrino_PU200.v0.root',
            #path+'perfNano_VBF_HToInvisible_PU200.v0.root',
 ]
 
-outfile = 'data/input_MET.h5'
+outfile = 'data/input_MET_PupCandi.h5'
 #entrystop = 10000
 entrystop = None
 
@@ -87,6 +87,7 @@ for infile in infiles:
     df_met = tree.pandas.df(branches=met_branches, entrystart=0, entrystop = entrystop)
     df_jet = tree.pandas.df(branches=jet_branches, entrystart=0, entrystop = entrystop)
     df_pupcandi = tree.pandas.df(branches=pupcandi_branches, entrystart=0, entrystop = entrystop)
+    print(df_pupcandi)
 
     ####### for test what is differences btw df_jet and df_pupcandi
 

--- a/convert-uproot.py
+++ b/convert-uproot.py
@@ -10,8 +10,9 @@ filters = tables.Filters(complevel=7, complib='blosc')
 path = 'data/'
 
 infiles = [#path+'perfNano_SingleNeutrino_PU200.v0.root',
-           path+'perfNano_TTbar_PU200.v0.root',
-           path+'perfNano_VBF_HToInvisible_PU200.v0.root',
+           #path+'perfNano_TTbar_PU200.v0.root'
+           path+'perfNano_TTbar_PU200.110X_v1.root'
+           #path+'perfNano_VBF_HToInvisible_PU200.v0.root',
 ]
 
 outfile = 'data/input_MET.h5'
@@ -51,15 +52,18 @@ met_branches = [# barrel
                 'L1TKV5Met_pt', 'L1TKV5Met_phi',
                 'L1TKV6Met_pt', 'L1TKV6Met_phi',
                 'L1TKVMet_pt', 'L1TKVMet_phi',
-                'genMet_pt', 'genMet_phi'
-]
+                'genMet_pt', 'genMet_phi']
 
 jet_branches =['L1PuppiJets_pt','L1PuppiJets_eta','L1PuppiJets_phi', 
                'L1PuppiJets_mass']
 
+pupcandi_branches =['L1PuppiCands_pt','L1PuppiCands_eta','L1PuppiCands_phi',
+                   'L1PuppiCands_charge','L1PuppiCands_pdgId','L1PuppiCands_puppiWeight']
+
 print("Reading branches", other_branches)
 print("Reading branches:", met_branches)
 print("Reading branches:", jet_branches)
+print("Reading branches:", pupcandi_branches)
 
 def _write_carray(a, h5file, name, group_path='/', **kwargs):
     h5file.create_carray(group_path, name, obj=a, filters=filters, createparents=True, **kwargs)
@@ -70,6 +74,7 @@ def _transform(dataframe, max_particles=100, start=0, stop=-1):
 df_others = []
 df_mets = []
 df_jets = []
+df_pupcandis = []
 
 currententry = 0
 for infile in infiles:
@@ -81,6 +86,14 @@ for infile in infiles:
     df_other = tree.pandas.df(branches=other_branches, entrystart=0, entrystop = entrystop)
     df_met = tree.pandas.df(branches=met_branches, entrystart=0, entrystop = entrystop)
     df_jet = tree.pandas.df(branches=jet_branches, entrystart=0, entrystop = entrystop)
+    df_pupcandi = tree.pandas.df(branches=pupcandi_branches, entrystart=0, entrystop = entrystop)
+
+    ####### for test what is differences btw df_jet and df_pupcandi
+
+    print(df_other)
+    print(df_jet)
+    print(df_pupcandi)
+
 
     # first find total length of evens-level dataframe before cuts
     # for re-indexing later (to avoid making duplicaes)
@@ -94,16 +107,19 @@ for infile in infiles:
     df_other.index = df_other.index+currententry
     df_met.index = df_met.index+currententry
     df_jet.index = df_jet.index.set_levels(df_jet.index.levels[0]+currententry, level=0)
+    df_pupcandi.index = df_pupcandi.index.set_levels(df_pupcandi.index.levels[0]+currententry, level=0)
 
     currententry += totallength
 
     df_others.append(df_other)
     df_mets.append(df_met)
     df_jets.append(df_jet)
+    df_pupcandis.append(df_pupcandi)
     
 df_other = pd.concat(df_others)
 df_met = pd.concat(df_mets)
 df_jet = pd.concat(df_jets)
+df_pupcandi = pd.concat(df_pupcandis)
 
 
 # shuffle
@@ -111,6 +127,7 @@ df_other = df_other.sample(frac=1)
 # apply new ordering to other dataframes
 df_met = df_met.reindex(df_other.index.values)
 df_jet = df_jet.reindex(df_other.index.values,level=0)
+df_pupcandi = df_pupcandi.reindex(df_other.index.values,level=0)
 
 
 with tables.open_file(outfile, mode='w') as h5file:
@@ -118,12 +135,19 @@ with tables.open_file(outfile, mode='w') as h5file:
     #max_jet = len(df_jet.index.get_level_values(-1).unique())
     # cap at 20 jets
     max_jet = 20
+    max_pupcandi = 100
     print("Max number of jets",max_jet)
+    print("Max number of pupcandi",max_pupcandi)
     
     v_jet = _transform(df_jet, max_particles = max_jet)
     for k in jet_branches:
         v = np.stack([v_jet[(k, i)].values for i in range(max_jet)], axis=-1)
         _write_carray(v, h5file, name=k)
+        
+    z_pupcandi = _transform(df_pupcandi, max_particles = max_pupcandi)
+    for k in pupcandi_branches:
+        z = np.stack([z_pupcandi[(k, i)].values for i in range(max_pupcandi)], axis=-1)
+        _write_carray(z, h5file, name=k)
         
     for k in df_other.columns:
         _write_carray(df_other[k].values, h5file, name=k.replace('[','').replace(']',''))

--- a/get_jet.py
+++ b/get_jet.py
@@ -25,7 +25,7 @@ def get_features_targets(file_name, features, targets):
     h5file.close()
     return feature_array,target_array
 
-def get_jet_features_targets(file_name, features, number_of_jets):
+def get_jet_features(file_name, features, number_of_jets):
     # load file
     h5file = tables.open_file(file_name, 'r')
     nevents = getattr(h5file.root,features[0]).shape[0]
@@ -33,11 +33,11 @@ def get_jet_features_targets(file_name, features, number_of_jets):
     print(nevents)
 
     # allocate arrays
-    feature_array = np.zeros((nevents,nfeatures*number_of_jets))
+    feature_array = np.zeros((nevents,number_of_jets,nfeatures))
 
     # load feature arrays
-    for (i, feat) in enumerate(features):
-        for j in range(number_of_jets):
-            feature_array[:,(j*number_of_jets)+i] = getattr(h5file.root, feat)[:,j]
+    for j in range(number_of_jets):
+        for (i, feat) in enumerate(features):
+            feature_array[:,j,i] = getattr(h5file.root, feat)[:,j]
     h5file.close()
     return feature_array

--- a/models.py
+++ b/models.py
@@ -10,14 +10,11 @@ def dense(ninputs, noutputs):
 
     x = BatchNormalization(name='bn_1')(inputs)
     x = Dense(64, name = 'dense_1', activation='relu', kernel_initializer='glorot_uniform')(x)
-    x = Dropout(rate=0.1)(x)
 
     x = Dense(32, name = 'dense_2', activation='relu', kernel_initializer='glorot_uniform')(x)
-    x = Dropout(rate=0.1)(x)
 
     x = Dense(32, name = 'dense_3', activation='relu', kernel_initializer='glorot_uniform')(x)
-    x = Dropout(rate=0.1)(x)
-    
+
     outputs = Dense(noutputs, name = 'output', activation='linear')(x)
 
     outputs0 = Lambda(lambda x: slice(x, (0, 0), (-1,  1)))(outputs)
@@ -27,6 +24,7 @@ def dense(ninputs, noutputs):
 
     return keras_model
 
+
 def dense_conv(ndenseinputs, nconvs, nconvinputs, noutputs):
 
     inputs_dense = Input(shape=(ndenseinputs,), name = 'input_dense')
@@ -34,23 +32,22 @@ def dense_conv(ndenseinputs, nconvs, nconvinputs, noutputs):
 
     x = BatchNormalization(name='bn_1')(inputs_dense)
     x = Dense(64, name = 'dense_1', activation='relu', kernel_initializer='glorot_uniform')(x)
-    x = Dropout(rate=0.1)(x)
 
     x = Dense(32, name = 'dense_2', activation='relu', kernel_initializer='glorot_uniform')(x)
-    x = Dropout(rate=0.1)(x)
 
     x = Dense(32, name = 'dense_3', activation='relu', kernel_initializer='glorot_uniform')(x)
-    x = Dropout(rate=0.1)(x)
 
     y = BatchNormalization(name='bn_2')(inputs_conv)
-    y = Conv1D(filters=32, kernel_size=(1,), strides=(1,), padding='same', 
-               kernel_initializer='he_normal', use_bias=False, name='conv1',
+    y = Conv1D(filters=64, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_1',
                activation = 'relu')(y)
-    y = SpatialDropout1D(rate=0.1)(y)
     y = Conv1D(filters=32, kernel_size=(1,), strides=(1,), padding='same', 
-               kernel_initializer='he_normal', use_bias=False, name='conv2',
+               kernel_initializer='he_normal', use_bias=True, name='conv_2',
                activation = 'relu')(y)
-    y = SpatialDropout1D(rate=0.1)(y)
+    y = Conv1D(filters=32, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_3',
+               activation = 'relu')(y)
+
     # Try GRU
     #y = GRU(50,go_backwards=True,implementation=2,name='gru')(y)
     # Try summing over jets
@@ -59,7 +56,8 @@ def dense_conv(ndenseinputs, nconvs, nconvinputs, noutputs):
     #y = Flatten()(y)
     
     concat = Concatenate()([x,y])
-    z = Dense(100, name = 'dense_4', activation='relu', kernel_initializer='glorot_uniform')(concat)
+    z = Dense(128, name = 'dense_4', activation='relu', kernel_initializer='glorot_uniform')(concat)
+    z = Dense(128, name = 'dense_5', activation='relu', kernel_initializer='glorot_uniform')(z)
     outputs = Dense(noutputs, name = 'output', activation='linear')(z)
 
     outputs0 = Lambda(lambda x: slice(x, (0, 0), (-1,  1)))(outputs)
@@ -69,3 +67,69 @@ def dense_conv(ndenseinputs, nconvs, nconvinputs, noutputs):
 
     return keras_model
 
+def conv(nconvs, nconvinputs, noutputs):
+
+    inputs_conv = Input(shape=(nconvs, nconvinputs,), name = 'input_conv')
+
+    y = BatchNormalization(name='bn_2')(inputs_conv)
+    y = Conv1D(filters=64, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_1',
+               activation = 'relu')(y)
+    y = Conv1D(filters=32, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_2',
+               activation = 'relu')(y)
+    y = Conv1D(filters=32, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_3',
+               activation = 'relu')(y)
+
+    y = Lambda(lambda x: K.mean(x, axis=-2), input_shape=(nconvs,32)) (y) 
+                 
+    y = Dense(128, name = 'dense_1', activation='relu', kernel_initializer='glorot_uniform')(y)
+    y = Dense(128, name = 'dense_2', activation='relu', kernel_initializer='glorot_uniform')(y)
+
+    outputs = Dense(noutputs, name = 'output', activation='linear')(y)
+
+    outputs0 = Lambda(lambda x: slice(x, (0, 0), (-1,  1)))(outputs)
+    outputs1 = Lambda(lambda x: slice(x, (0, 1), (-1, -1)))(outputs)
+
+    keras_model = Model(inputs=inputs_conv, outputs=[outputs0, outputs1])
+
+    return keras_model
+
+# weight multiply bias sum
+def weight_multiply_bias_sum(ip):
+    w = slice(ip[0], (0, 0, 0), (-1, -1, 1))
+    b = slice(ip[0], (0, 0, 1), (-1, -1, -1))
+    x = slice(ip[1], (0, 0, 0), (-1, -1, 2))
+    return K.sum(w*x+b,axis=-2)
+
+def deepmetlike(nconvs, nconvinputs, noutputs):
+
+    inputs_conv = Input(shape=(nconvs, nconvinputs,), name = 'input_conv')
+
+    y = BatchNormalization(name='bn_1')(inputs_conv)
+    y = Conv1D(filters=64, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_1',
+               activation = 'relu')(y)
+    y = BatchNormalization(name='bn_2')(y)
+    y = Conv1D(filters=32, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_2',
+               activation = 'relu')(y)
+    y = BatchNormalization(name='bn_3')(y)
+    y = Conv1D(filters=16, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_3',
+               activation = 'relu')(y)
+    y = BatchNormalization(name='bn_4')(y)
+    y = Conv1D(filters=3, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=True, name='conv_4',
+               activation = 'linear')(y)
+
+    # Try multiplying
+    outputs = Lambda(weight_multiply_bias_sum) ([y,inputs_conv])
+    
+    outputs0 = Lambda(lambda x: slice(x, (0, 0), (-1,  1)))(outputs)
+    outputs1 = Lambda(lambda x: slice(x, (0, 1), (-1, -1)))(outputs)
+
+    keras_model = Model(inputs=inputs_conv, outputs=[outputs0, outputs1])
+
+    return keras_model

--- a/models.py
+++ b/models.py
@@ -1,25 +1,22 @@
 import keras
 from keras.models import Model
-from keras.layers import Input, Dense, BatchNormalization, Dropout, Lambda
+from keras.layers import Input, Dense, BatchNormalization, Dropout, Lambda, Conv1D, SpatialDropout1D, Concatenate, Flatten
+import keras.backend as K
 from keras.backend import slice
 
 def dense(ninputs, noutputs):
 
     inputs = Input(shape=(ninputs,), name = 'input')
 
-
     x = BatchNormalization(name='bn_1')(inputs)
     x = Dense(64, name = 'dense_1', activation='relu', kernel_initializer='glorot_uniform')(x)
     x = Dropout(rate=0.1)(x)
 
-
-    x = Dense(32, name = 'dense_2', activation='relu')(x)
+    x = Dense(32, name = 'dense_2', activation='relu', kernel_initializer='glorot_uniform')(x)
     x = Dropout(rate=0.1)(x)
 
-
-    x = Dense(32, name = 'dense_3', activation='relu')(x)
+    x = Dense(32, name = 'dense_3', activation='relu', kernel_initializer='glorot_uniform')(x)
     x = Dropout(rate=0.1)(x)
-
     
     outputs = Dense(noutputs, name = 'output', activation='linear')(x)
 
@@ -27,6 +24,48 @@ def dense(ninputs, noutputs):
     outputs1 = Lambda(lambda x: slice(x, (0, 1), (-1, -1)))(outputs)
 
     keras_model = Model(inputs=inputs, outputs=[outputs0, outputs1])
+
+    return keras_model
+
+def dense_conv(ndenseinputs, nconvs, nconvinputs, noutputs):
+
+    inputs_dense = Input(shape=(ndenseinputs,), name = 'input_dense')
+    inputs_conv = Input(shape=(nconvs, nconvinputs,), name = 'input_conv')
+
+    x = BatchNormalization(name='bn_1')(inputs_dense)
+    x = Dense(64, name = 'dense_1', activation='relu', kernel_initializer='glorot_uniform')(x)
+    x = Dropout(rate=0.1)(x)
+
+    x = Dense(32, name = 'dense_2', activation='relu', kernel_initializer='glorot_uniform')(x)
+    x = Dropout(rate=0.1)(x)
+
+    x = Dense(32, name = 'dense_3', activation='relu', kernel_initializer='glorot_uniform')(x)
+    x = Dropout(rate=0.1)(x)
+
+    y = BatchNormalization(name='bn_2')(inputs_conv)
+    y = Conv1D(filters=32, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=False, name='conv1',
+               activation = 'relu')(y)
+    y = SpatialDropout1D(rate=0.1)(y)
+    y = Conv1D(filters=32, kernel_size=(1,), strides=(1,), padding='same', 
+               kernel_initializer='he_normal', use_bias=False, name='conv2',
+               activation = 'relu')(y)
+    y = SpatialDropout1D(rate=0.1)(y)
+    # Try GRU
+    #y = GRU(50,go_backwards=True,implementation=2,name='gru')(y)
+    # Try summing over jets
+    y = Lambda(lambda x: K.mean(x, axis=-2), input_shape=(nconvs,32)) (y)
+    # Try flattening all jets
+    #y = Flatten()(y)
+    
+    concat = Concatenate()([x,y])
+    z = Dense(100, name = 'dense_4', activation='relu', kernel_initializer='glorot_uniform')(concat)
+    outputs = Dense(noutputs, name = 'output', activation='linear')(z)
+
+    outputs0 = Lambda(lambda x: slice(x, (0, 0), (-1,  1)))(outputs)
+    outputs1 = Lambda(lambda x: slice(x, (0, 1), (-1, -1)))(outputs)
+
+    keras_model = Model(inputs=[inputs_dense,inputs_conv], outputs=[outputs0, outputs1])
 
     return keras_model
 

--- a/train.py
+++ b/train.py
@@ -128,7 +128,7 @@ def main(args):
         feature_pupcandi_array_xy[:,i,2] = feature_pupcandi_array[:,i,2]
         feature_pupcandi_array_xy[:,i,3] = feature_pupcandi_array[:,i,3]
         feature_pupcandi_array_xy[:,i,4] = feature_pupcandi_array[:,i,4]
-        feature_pupcandi_array_xy[:,i,4] = feature_pupcandi_array[:,i,4]
+        feature_pupcandi_array_xy[:,i,5] = feature_pupcandi_array[:,i,5]
     
     
     # Convert target from pt phi to px, py

--- a/train.py
+++ b/train.py
@@ -1,4 +1,4 @@
-import tensorflow
+import tensorflow 
 from tensorflow.python.ops import math_ops
 import keras
 from keras.callbacks import ModelCheckpoint, EarlyStopping
@@ -7,10 +7,11 @@ import numpy as np
 import tables
 import matplotlib.pyplot as plt
 import argparse
-from models import dense
+from models import dense, dense_conv
 import math
-from Write_MET_binned_histogram import *
-from get_jet import * 
+import setGPU
+from Write_MET_binned_histogram import MET_rel_error, MET_binned_predict_mean
+from get_jet import get_features_targets, get_jet_features
 
 def huber_loss(y_true, y_pred, delta=1.0):
     error = y_pred - y_true
@@ -21,38 +22,27 @@ def huber_loss(y_true, y_pred, delta=1.0):
 
 def weight_loss_function(number_of_bin, val_array, min_, max_):
     binning = (max_ - min_)/number_of_bin
+    bins = np.linspace(min_,max_,number_of_bin+1)
+
     val_events = val_array.shape[0]
     mean = val_events/number_of_bin
     global MET_interval
     MET_interval = np.zeros(number_of_bin)
 
-    for i in range(val_events):
-        for j in range(number_of_bin):
-            if (binning * j <= math.sqrt(val_array[i,0] ** 2 + val_array[i,1] ** 2) < binning * (j + 1)):
-                MET_interval[j] = MET_interval[j] + 1
-                break
+    met = np.sqrt(val_array[:,0] ** 2 + val_array[:,1] ** 2)    
+    MET_interval, _ = np.histogram(met,bins)
 
-    def allocate_weight(val_):
-        k = 0
-        for i in range(number_of_bin):
-            if (binning * i <= val_ < binning * (i + 1)):
-                break
-        k = MET_interval[i]
-        if k == 0:
-            k = 1
-        return mean/k
+    bin_indices = np.digitize(met,bins)-1
+    bin_indices = np.clip(bin_indices,0,number_of_bin-1) # make last bin an overflow
 
-    weight_array = np.zeros(val_events)
-    
-    for i in range(val_events):
-        weight_array[i] = allocate_weight(math.sqrt(val_array[i,0] ** 2 + val_array[i,1] ** 2))
+    weight_array = np.full(val_events, mean)/MET_interval[bin_indices]
 
     return weight_array
 
 
 def main(args):
 
-    file_path = 'input_MET.h5'
+    file_path = 'data/input_MET.h5'
     features = ['L1CHSMet_pt', 'L1CHSMet_phi',
                 'L1CaloMet_pt', 'L1CaloMet_phi',
                 'L1PFMet_pt', 'L1PFMet_phi',
@@ -65,60 +55,53 @@ def main(args):
     targets = ['genMet_pt', 'genMet_phi']
     targets_jet = ['GenJets_pt', 'GenJets_phi', 'GenJets_eta']
 
-    ## Set number of jets you will use
-    number_of_jets = 3
+    # Set number of jets you will use
+    number_of_jets = 10
 
     feature_MET_array, target_array = get_features_targets(file_path, features, targets)
-    feature_jet_array = get_jet_features_targets(file_path, features_jet, number_of_jets)
-    nMETs = feature_MET_array.shape[1]
-    feature_array = np.concatenate((feature_MET_array, feature_jet_array), axis=1)
+    feature_jet_array = get_jet_features(file_path, features_jet, number_of_jets)
+    nMETs = int(feature_MET_array.shape[1]/2)
+    print(nMETs)
 
-    nevents = feature_array.shape[0]
-    nfeatures = feature_array.shape[1]
+    nevents = target_array.shape[0]
+    nmetfeatures = feature_MET_array.shape[1]
+    njets = feature_jet_array.shape[1]
+    njetfeatures = feature_jet_array.shape[2]
     ntargets = target_array.shape[1]
 
-
     # Exclude puppi met < 100 GeV events
-    ## Set PUPPI MET min, max cut
+    # Set PUPPI MET min, max cut
 
     PupMET_cut = 0
     PupMET_cut_max = 500
 
-    mask1= (feature_array[:,0] < PupMET_cut)
-    feature_array = feature_array[~mask1]
-    target_array = target_array[~mask1]
+    mask = (feature_MET_array[:,0] > PupMET_cut) & (feature_MET_array[:,0] < PupMET_cut_max)
+    feature_MET_array = feature_MET_array[mask]
+    feature_jet_array = feature_jet_array[mask]
+    target_array = target_array[mask]
 
-    mask2= (feature_array[:,0] > PupMET_cut_max)
-    feature_array = feature_array[~mask2]
-    target_array = target_array[~mask2]
-
-    nevents = feature_array.shape[0]
+    nevents = target_array.shape[0]
 
     # Convert feature from pt, phi to px, py
-    feature_array_xy = np.zeros((nevents, nfeatures))
+    feature_MET_array_xy = np.zeros((nevents, nmetfeatures))
     for i in range(nMETs):
-        if i%2 == 0:
-            feature_array_xy[:,i] = feature_array[:,i] * np.cos(feature_array[:,i+1])
-        if i%2 == 1:
-            feature_array_xy[:,i] = feature_array[:,i-1] * np.sin(feature_array[:,i])
+        feature_MET_array_xy[:,2*i] =   feature_MET_array[:,2*i] * np.cos(feature_MET_array[:,2*i+1])
+        feature_MET_array_xy[:,2*i+1] = feature_MET_array[:,2*i] * np.sin(feature_MET_array[:,2*i+1])
 
-    for i in range(3*number_of_jets):
-        if i%3 == 0:
-            feature_array_xy[:,i+nMETs] = feature_array[:,i+nMETs] * np.cos(feature_array[:,i+nMETs+1])
-        if i%3 == 1:
-            feature_array_xy[:,i+nMETs] = feature_array[:,i+nMETs-1] * np.sin(feature_array[:,i+nMETs])
-        if i%3 == 2:
-            feature_array_xy[:,i+nMETs] = feature_array[:,i+nMETs]
+    feature_jet_array_xy = np.zeros((nevents, njets, njetfeatures))
+    for i in range(number_of_jets):
+        feature_jet_array_xy[:,i,0] = feature_jet_array[:,i,0] * np.cos(feature_jet_array[:,i,1])
+        feature_jet_array_xy[:,i,1] = feature_jet_array[:,i,0] * np.sin(feature_jet_array[:,i,1])
+        feature_jet_array_xy[:,i,2] = feature_jet_array[:,i,2]
     
     # Convert target from pt phi to px, py
     target_array_xy = np.zeros((nevents, ntargets))
 
     target_array_xy[:,0] = target_array[:,0] * np.cos(target_array[:,1])
     target_array_xy[:,1] = target_array[:,0] * np.sin(target_array[:,1])
-
     
     # Split datas into train, validation, test set
-    X = feature_array_xy
+    X = [feature_MET_array_xy, feature_jet_array_xy]
     y = target_array_xy
     
     fulllen = nevents
@@ -127,23 +110,19 @@ def main(args):
     splits = np.cumsum([fulllen-2*tv_num,tv_num,tv_num])
     splits = [int(s) for s in splits]
 
-    X_train = X[0:splits[0]]
-    X_val = X[splits[1]:splits[2]]
-    X_test = X[splits[0]:splits[1]]
+    X_train = [xi[0:splits[0]] for xi in X]
+    X_val = [xi[splits[1]:splits[2]] for xi in X]
+    X_test = [xi[splits[0]:splits[1]] for xi in X]
 
     y_train = y[0:splits[0]]
     y_val = y[splits[1]:splits[2]]
     y_test = y[splits[0]:splits[1]]
 
-
-
     # Make weight loss function
     weight_array = weight_loss_function(20, y_train, 0, 500)
 
-
-
     # Set keras train model
-    keras_model = dense(nfeatures, ntargets)
+    keras_model = dense_conv(nmetfeatures, njets, njetfeatures, ntargets)
 
     keras_model.compile(optimizer='adam', loss=['mean_squared_error', 'mean_squared_error'], 
                         loss_weights = None, metrics=['mean_absolute_error'])
@@ -154,12 +133,15 @@ def main(args):
     callbacks = [early_stopping, model_checkpoint]
 
 
-
     # fit keras
-    keras_model.fit(X_train, [y_train[:,:1], y_train[:,1:]], batch_size=1024, sample_weight = [weight_array, weight_array], 
-                epochs=100, validation_data=(X_val, [y_val[:,:1], y_val[:,1:]]), shuffle=True,
-                callbacks = callbacks)
-
+    keras_model.fit(X_train, 
+                    [y_train[:,:1], y_train[:,1:]], 
+                    batch_size=1024, 
+                    sample_weight=[weight_array, weight_array], 
+                    epochs=100, 
+                    validation_data=(X_val, [y_val[:,:1], y_val[:,1:]]), 
+                    shuffle=True,
+                    callbacks=callbacks)
 
 
     # load created weights
@@ -168,8 +150,6 @@ def main(args):
     predict_test = keras_model.predict(X_test)
     predict_test = np.concatenate(predict_test,axis=1)
 
-
-
     # convert px py into pt phi
     test_events = predict_test.shape[0]
 
@@ -177,20 +157,12 @@ def main(args):
     y_test_phi = np.zeros((test_events, 2))
 	
     predict_phi[:,0] = np.sqrt((predict_test[:,0]**2 + predict_test[:,1]**2))
-    for i in range(test_events):
-        if 0 < predict_test[i,1]:
-            predict_phi[i,1] = math.acos(predict_test[i,0]/predict_phi[i,0])
-        if predict_test[i,1] < 0:
-            predict_phi[i,1] = -math.acos(predict_test[i,0]/predict_phi[i,0])
-    
-        y_test_phi[:,0] = np.sqrt((y_test[:,0]**2 + y_test[:,1]**2))
-    for i in range(test_events):
-        if 0 < y_test[i,1]:
-            y_test_phi[i,1] = math.acos(y_test[i,0]/y_test_phi[i,0])
-        if y_test[i,1] < 0:
-            y_test_phi[i,1] = -math.acos(y_test[i,0]/y_test_phi[i,0])
+    predict_phi[:,1] = np.sign(predict_phi[:,1])*np.arccos(predict_test[:,0]/predict_phi[:,0])
 
-    Write_MET_binned_histogram(predict_phi, y_test_phi, 20, 0, 100, 400, name='histogram_all_no100cut.root')
+    y_test_phi[:,0] = np.sqrt((y_test[:,0]**2 + y_test[:,1]**2))
+    y_test_phi[:,1] = np.sign(y_test[:,1])*np.arccos(y_test[:,0]/y_test_phi[:,0])
+
+    #Write_MET_binned_histogram(predict_phi, y_test_phi, 20, 0, 100, 400, name='histogram_all_no100cut.root')
 
     MET_rel_error(predict_phi[:,0], y_test_phi[:,0], name='rel_error_weight.png')
     MET_binned_predict_mean(predict_phi[:,0], y_test_phi[:,0], 20, 0, 500, 0, '.', name='predict_mean.png')

--- a/train.py
+++ b/train.py
@@ -166,10 +166,13 @@ def main(args):
     # Set keras train model (and correct input)
 
     # met+jet-based model
-    keras_model = dense_conv(nmetfeatures, njets, njetfeatures, ntargets)
+    #keras_model = dense_conv(nmetfeatures, njets, njetfeatures, ntargets)
+    #X_train = X_train[:2]
+    #X_val = X_val[:2]
+    #X_val = X_test[:2]
 
     # met+jet+PupCandi-based model
-    #keras_model = dense_conv_all(nmetfeatures, njets, njetfeatures, npupcandis, npupcandifeatures, ntargets)
+    keras_model = dense_conv_all(nmetfeatures, njets, njetfeatures, npupcandis, npupcandifeatures, ntargets)
 
     # only-met-based model
     #keras_model = dense(nmetfeatures, ntargets); 


### PR DESCRIPTION
@ExcitingSquid @therwig 

- Here's an example of a really simple conv model for the jet inputs. Actually it's not even really convolutional because the kernel size is 1 (so it's more like the DeepSets approach).
- A lot of optimization can be done here (number of jet inputs, topology of the model, etc.)
- I also added set up to train with a GPU (as this will most likely be necessary as the model becomes bigger). Do you have GPU resources available? If not, I can try to get you access to some.
- Are the most recent inputs the ones here: `/afs/cern.ch/work/d/daekwon/public/l1samples/`?

![predict_mean](https://user-images.githubusercontent.com/4932543/83696575-9f61c280-a5b1-11ea-8e1b-39b458f31dbe.png)
![rel_error_weight](https://user-images.githubusercontent.com/4932543/83696582-a4bf0d00-a5b1-11ea-9b48-d37c9a826d87.png)
